### PR TITLE
[Fixed]Issues #67 アジェンダの削除機能を実装すること（紐づいている記事も削除し、そのアジェンダのチームに属しているメンバー全員に通知メールを送信すること

### DIFF
--- a/app/controllers/agendas_controller.rb
+++ b/app/controllers/agendas_controller.rb
@@ -1,5 +1,5 @@
 class AgendasController < ApplicationController
-  # before_action :set_agenda, only: %i[show edit update destroy]
+  before_action :set_agenda, only: %i[show edit update destroy]
 
   def index
     @agendas = Agenda.all
@@ -15,10 +15,15 @@ class AgendasController < ApplicationController
     @agenda.team = Team.friendly.find(params[:team_id])
     current_user.keep_team_id = @agenda.team.id
     if current_user.save && @agenda.save
-      redirect_to dashboard_url, notice: I18n.t('views.messages.create_agenda') 
+      redirect_to dashboard_url, notice: I18n.t('views.messages.create_agenda')
     else
       render :new
     end
+  end
+
+  def destroy
+    @agenda.destroy
+    redirect_to dashboard_url
   end
 
   private

--- a/app/controllers/agendas_controller.rb
+++ b/app/controllers/agendas_controller.rb
@@ -24,6 +24,7 @@ class AgendasController < ApplicationController
   def destroy
     if @agenda.user_id == current_user.id || @agenda.team.owner_id == current_user.id
       @agenda.destroy
+      AgendaMailer.agenda_mail(@agenda).deliver
       redirect_to dashboard_url
     end
   end

--- a/app/controllers/agendas_controller.rb
+++ b/app/controllers/agendas_controller.rb
@@ -22,8 +22,10 @@ class AgendasController < ApplicationController
   end
 
   def destroy
-    @agenda.destroy
-    redirect_to dashboard_url
+    if @agenda.user_id == current_user.id || @agenda.team.owner_id == current_user.id
+      @agenda.destroy
+      redirect_to dashboard_url
+    end
   end
 
   private

--- a/app/controllers/assigns_controller.rb
+++ b/app/controllers/assigns_controller.rb
@@ -62,7 +62,7 @@ class AssignsController < ApplicationController
     change_keep_team(assigned_user, another_team) if assigned_user.keep_team_id == assign.team_id
   end
 
-  def find_team(team_id)
+  def find_team(_team_id)
     Team.friendly.find(params[:team_id])
   end
 end

--- a/app/mailers/agenda_mailer.rb
+++ b/app/mailers/agenda_mailer.rb
@@ -1,6 +1,7 @@
 class AgendaMailer < ApplicationMailer
   def agenda_mail(agenda)
     @agenda = agenda
-    mail to: , subject: "agenda削除のお知らせ"
+    team_member = @agenda.team.assigns.map(&:user)
+    mail to: team_member.map(&:email), subject: "agenda削除のお知らせ"
   end
 end

--- a/app/mailers/agenda_mailer.rb
+++ b/app/mailers/agenda_mailer.rb
@@ -1,0 +1,6 @@
+class AgendaMailer < ApplicationMailer
+  def agenda_mail(agenda)
+    @agenda = agenda
+    mail to: , subject: "agenda削除のお知らせ"
+  end
+end

--- a/app/views/agenda_mailer/agenda_mail.html.erb
+++ b/app/views/agenda_mailer/agenda_mail.html.erb
@@ -1,0 +1,2 @@
+<h1>agendaが削除されました</h1>
+<h4>agenda名: <%= @agenda.title %></h4>

--- a/app/views/shared/layout/_sidebar.html.erb
+++ b/app/views/shared/layout/_sidebar.html.erb
@@ -33,8 +33,13 @@
             <a href="#" class="nav-link">
               <i class="fa fa-circle-o nav-icon"></i>
               <p>
-                <%= agenda.title %>
-                <i class="right fa fa-angle-left"></i>
+                <table>
+                  <tr>
+                    <%= agenda.title %>
+                    <%= link_to '削除', agenda, method: :delete, data: { confirm: '削除しますか?' }, class:"btn btn-info" %>
+                    <i class="right fa fa-angle-left"></i>
+                  </tr>
+                </table>
               </p>
             </a>
             <ul class="nav nav-treeview" style="display: block;">

--- a/app/views/shared/layout/_sidebar.html.erb
+++ b/app/views/shared/layout/_sidebar.html.erb
@@ -36,7 +36,9 @@
                 <table>
                   <tr>
                     <%= agenda.title %>
+                      <% if agenda.user_id == current_user.id || agenda.team.owner_id == current_user.id %>
                     <%= link_to '削除', agenda, method: :delete, data: { confirm: '削除しますか?' }, class:"btn btn-info" %>
+                    <% end %>
                     <i class="right fa fa-angle-left"></i>
                   </tr>
                 </table>

--- a/spec/mailers/agenda_mailer_spec.rb
+++ b/spec/mailers/agenda_mailer_spec.rb
@@ -1,0 +1,5 @@
+require "rails_helper"
+
+RSpec.describe AgendaMailer, type: :mailer do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/mailers/previews/agenda_mailer_preview.rb
+++ b/spec/mailers/previews/agenda_mailer_preview.rb
@@ -1,0 +1,4 @@
+# Preview all emails at http://localhost:3000/rails/mailers/agenda_mailer
+class AgendaMailerPreview < ActionMailer::Preview
+
+end


### PR DESCRIPTION
AgendasControllerのdestroyアクションを追加し、そこに機能追加する
Agendaの名前の右の部分に削除ボタンを作成し、そのボタンを押すとそのAgendaが削除される
Agendaに紐づいているarticleも一緒に削除される
Agendaを削除できるのは、そのAgendaの作者もしくはそのAgendaに紐づいているTeamの作者（オーナー）のみ
Agendaが削除されると、そのAgendaに紐づいているTeamに所属しているユーザー全員に通知メールが飛ぶ
情報処理が完了した後はDashBoardに飛ぶ
その他、アプリケーションの挙動に不審な点やエラーがないこと